### PR TITLE
Vsize bug fix

### DIFF
--- a/UI/Loupe.py
+++ b/UI/Loupe.py
@@ -580,7 +580,7 @@ class Loupe(Widget, EventChildClass):
 
         #MENU BAR
         self.mBar = QtWidgets.QMenuBar(self)
-        self.menuHandler = MenuHandler(self)
+        self.menuHandler = MenuHandler(self, mode="loupe")
         self.layout.setMenuBar(self.mBar)
 
     # Adding menu bar getter for MenuHandler to be able to properly initialize the menu

--- a/UI/Loupe.py
+++ b/UI/Loupe.py
@@ -544,7 +544,7 @@ class Loupe(Widget, EventChildClass):
         self.initialiseSettings()
 
         self.resize(1100, 800)
-        self.setWindowTitle(f"Loupe {N}")
+        self.setWindowTitle(f"3D View {N}")
 
         # SIDEBAR HERE
         self.sideBarContainer = Widget(layout="vertical", parent=self)

--- a/UI/Templates.py
+++ b/UI/Templates.py
@@ -1792,7 +1792,7 @@ class BigDatasetWarningDialog(QDialog):
             "The dataset that you selected is very big. "
             "For efficient processing, you might want to select samples from the dataset "
             "(pick every 10 atomic structures or every 100, etc.). "
-            "If you are sure that your system can handle this dataset just press OK, "
+            "If you are sure that your system can handle this dataset just press 'Load as a whole', "
             "otherwise write your desired slice number in the box below and select "
             "'Pick samples'. "
             "If your system does not have enough resources, you still can press OK "
@@ -1817,7 +1817,7 @@ class BigDatasetWarningDialog(QDialog):
 
         # Buttons
         button_box = QDialogButtonBox()
-        button_box.addButton("OK", QDialogButtonBox.AcceptRole)
+        button_box.addButton("Load as a whole", QDialogButtonBox.AcceptRole)
         pick_btn = button_box.addButton("Pick samples", QDialogButtonBox.ActionRole)
 
         layout.addWidget(button_box)

--- a/UI/Templates.py
+++ b/UI/Templates.py
@@ -1776,9 +1776,11 @@ def customFileDialog(parent, fileTypes=None, extensions=None, save=False, direct
 
 
 class BigDatasetWarningDialog(QDialog):
-    def __init__(self, file_size_mb, parent=None):
+    def __init__(self, file_size_mb, dataset_length, parent=None):
         super().__init__(parent)
         self.user_clicked_pick_samples = False
+        self.user_clicked_load_no_cache = False
+        self.dataset_length = dataset_length
         self.setWindowTitle("Attention")
         self.resize(700, 250)
         self.setModal(True)
@@ -1792,12 +1794,15 @@ class BigDatasetWarningDialog(QDialog):
             "The dataset that you selected is very big. "
             "For efficient processing, you might want to select samples from the dataset "
             "(pick every 10 atomic structures or every 100, etc.). "
-            "If you are sure that your system can handle this dataset just press 'Load as a whole', "
+            "If you are sure that your system can handle this dataset just press 'Load as a whole (without caching)', "
             "otherwise write your desired slice number in the box below and select "
             "'Pick samples'. "
-            "If your system does not have enough resources, you still can press OK "
-            "but it will take a lot of time for the application to load and process "
-            "your dataset."
+            "If your system does not have enough resources, yet you still want to have all of the dataset you can click"
+            " on 'Load as a whole'. This way, your dataset will be stored partially on RAM and partially on hard "
+            "drive (like a caching mechanism), but it will greatly increase the computation time of the program."
+            "\n\nAlso, note that the RAM usage estimation shown below only specifies the required space to store the "
+            "dataset itself, the values used in plots are also stored in RAM to avoid recalculation. So, the "
+            "approximation suggests a minimum on the demanded volume."
         )
 
         label = QLabel(msg)
@@ -1811,13 +1816,16 @@ class BigDatasetWarningDialog(QDialog):
         layout.addWidget(self.slice_input)
 
         # RAM‑usage feedback label
-        self.ram_hint = QLabel("RAM usage estimate will appear here.")
+        self.ram_hint = QLabel(f"You require approximately {2*self.file_size_mb/1_000_000_000:.2f} GB of RAM "
+                               f"(dataset itself+ its prediction dataset in future)!\nDataset length: "
+                               f"{self.dataset_length} atoms.")
         self.ram_hint.setStyleSheet("color: #666; font-size: 10pt;")
         layout.addWidget(self.ram_hint)
 
         # Buttons
         button_box = QDialogButtonBox()
         button_box.addButton("Load as a whole", QDialogButtonBox.AcceptRole)
+        load_no_cache = button_box.addButton("Load as a whole (without caching)", QDialogButtonBox.AcceptRole)
         pick_btn = button_box.addButton("Pick samples", QDialogButtonBox.ActionRole)
 
         layout.addWidget(button_box)
@@ -1829,10 +1837,13 @@ class BigDatasetWarningDialog(QDialog):
         button_box.rejected.connect(self.reject)
         button_box.clicked.connect(self.on_button_clicked)
         pick_btn.clicked.connect(self.accept)
+        load_no_cache.clicked.connect(self.accept)
 
     def on_button_clicked(self, button):
         if button.text() == "Pick samples":
             self.user_clicked_pick_samples = True
+        elif button.text() == "Load as a whole (without caching)":
+            self.user_clicked_load_no_cache = True
 
     def update_ram_hint(self):
         text = self.slice_input.text().strip()
@@ -1842,15 +1853,16 @@ class BigDatasetWarningDialog(QDialog):
                 if slice_num <= 0:
                     hint = "Slice number must be a positive integer."
                 else:
-                    effective_size = self.file_size_mb / slice_num
+                    effective_size = (self.file_size_mb / slice_num)/1_000_000_000
                     hint = (
                         f"For this slice factor, you require approximately "
-                        f"{2*effective_size:.2f} GB of RAM (dataset itself+ its prediction dataset in future)."
+                        f"{2*effective_size:.2f} GB of RAM (dataset itself+ its prediction dataset in future)!"
+                        f"\nDataset length: {self.dataset_length//slice_num} atoms."
                     )
             except ValueError:
                 hint = "Please enter a valid integer slice number."
         else:
-            hint = "RAM usage estimate will appear here."
+            hint = f"RAM usage estimate will appear here.\nDataset length: {self.dataset_length} atoms."
 
         self.ram_hint.setText(hint)
 

--- a/UI/UIHandler.py
+++ b/UI/UIHandler.py
@@ -17,7 +17,7 @@ class UIHandler(EventClass):
     uiFilesPath = os.path.join("UI", "uiFiles")
     env = None
     tabs = []
-    loupes = []
+    loupes = 0
     loupeModules = []
     activeLoupe = None  # Currently active Loupe for menu actions
     workdir = None  # Working directory for file dialogs
@@ -42,25 +42,25 @@ class UIHandler(EventClass):
         self.quitReady = True
 
     def nLoupes(self):
-        return len(self.loupes)
+        return self.loupes
 
-    def getActiveLoupe(self):
-        """Get the currently active Loupe instance, or the most recently created one."""
+    """def getActiveLoupe(self):
+        \"""Get the currently active Loupe instance, or the most recently created one.\"""
         if self.activeLoupe is not None:
             return self.activeLoupe
         elif len(self.loupes) > 0:
             return self.loupes[-1]
-        return None
+        return None"""
 
     def newLoupe(self):
-        loupe = Loupe(self, len(self.loupes))
+        loupe = Loupe(self, self.loupes)
 
         for func in self.loupeModules:
             func(self, loupe)
 
         loupe.forceUpdate()
-        self.loupes.append(loupe)
-        self.activeLoupe = loupe  # Set as active Loupe
+        self.loupes += 1
+
         loupe.show()
         loupe.setFocus()
 

--- a/UI/UIHandler.py
+++ b/UI/UIHandler.py
@@ -3,6 +3,7 @@ import os
 import pyqtgraph
 from PySide6 import QtWidgets
 from PySide6.QtCore import QDir
+from PySide6.QtWidgets import QMessageBox
 
 from events import EventClass
 from UI.Loupe import Loupe
@@ -27,6 +28,7 @@ class UIHandler(EventClass):
         super().__init__(*args, **kwargs)
         self.workdir = workdir if workdir else os.getcwd()
         self.eventSubscribe("QUIT_READY", self.setQuitReady)
+        self.eventSubscribe('CLUSTER_FOR_VARIABLE', self.showCLusterVariable)
 
     def quitEvent(self):
         self.eventPush("QUIT_EVENT")
@@ -40,6 +42,15 @@ class UIHandler(EventClass):
 
     def setQuitReady(self):
         self.quitReady = True
+
+    def showCLusterVariable(self):
+        msg = QMessageBox(self.window)
+        msg.setWindowTitle("Notification")
+        msg.setText("The cluster errors feature is not supported for variable datasets.")
+        msg.setIcon(QMessageBox.Information)
+        msg.setStandardButtons(QMessageBox.Ok)
+
+        result = msg.exec()
 
     def nLoupes(self):
         return self.loupes

--- a/UI/menuHandler.py
+++ b/UI/menuHandler.py
@@ -39,59 +39,60 @@ def deep_getsizeof(obj, seen=None):
 
 
 class MenuHandler(EventClass):
-    def __init__(self, window):
+    def __init__(self, window, mode="main"):
         self.handler = window.handler
         self.window = window
+        self.mode = mode  # either "main" for the main window or "loupe" for loupes.
         self.connectActions()
 
     def connectActions(self):
         handler, window = (self.handler, self.window)
         mb = window.menuBar()
+        if self.mode == 'main':
+            # FILE
+            File = mb.addMenu("&File")
+            File.addAction("Save", self.onSave, "Ctrl+s")
+            File.addAction("Load", self.onLoad, "Ctrl+l")
 
-        # FILE
-        File = mb.addMenu("&File")
-        File.addAction("Save", self.onSave, "Ctrl+s")
-        File.addAction("Load", self.onLoad, "Ctrl+l")
+            File.addAction("Load Dataset", self.onDatasetLoad, "Ctrl+d")
+            File.addAction("Load Model", self.onModelLoad, "Ctrl+m")
 
-        File.addAction("Load Dataset", self.onDatasetLoad, "Ctrl+d")
-        File.addAction("Load Model", self.onModelLoad, "Ctrl+m")
+            File.addAction("Load Zero Model", self.onZeroModelLoad, "Ctrl+0")
+            File.addAction("Load Prediction", self.onPrepredictedModelLoad, "Ctrl+p")
 
-        File.addAction("Load Zero Model", self.onZeroModelLoad, "Ctrl+0")
-        File.addAction("Load Prediction", self.onPrepredictedModelLoad, "Ctrl+p")
-
-        # File.addAction("Preferences", self.onPreferences)
-        # File.addAction("Exit", self.onExit)
+            # File.addAction("Preferences", self.onPreferences)
+            # File.addAction("Exit", self.onExit)
 
         # LOUPE
         Loupe = mb.addMenu("&Loupe")
         Loupe.addAction("New", self.newLoupe, "Ctrl+n")
         Loupe.addSeparator()
+        if self.mode == "loupe":
+            # Bond Width submenu
+            bondMenu = Loupe.addMenu("Bond Width")
+            bondMenu.addAction("Thin (10)", lambda: self.setBondWidth(10))
+            bondMenu.addAction("Normal (25)", lambda: self.setBondWidth(25))
+            bondMenu.addAction("Thick (50)", lambda: self.setBondWidth(50))
+            bondMenu.addAction("Extra Thick (100)", lambda: self.setBondWidth(100))
+            # TODO: add custom bond width dialog
+            # bondMenu.addSeparator()
+            # bondMenu.addAction("Custom...", self.showBondWidthDialog)
 
-        # Bond Width submenu
-        bondMenu = Loupe.addMenu("Bond Width")
-        bondMenu.addAction("Thin (10)", lambda: self.setBondWidth(10))
-        bondMenu.addAction("Normal (25)", lambda: self.setBondWidth(25))
-        bondMenu.addAction("Thick (50)", lambda: self.setBondWidth(50))
-        bondMenu.addAction("Extra Thick (100)", lambda: self.setBondWidth(100))
-        # TODO: add custom bond width dialog
-        # bondMenu.addSeparator()
-        # bondMenu.addAction("Custom...", self.showBondWidthDialog)
+            # Atom Size submenu
+            atomMenu = Loupe.addMenu("Atom Size")
+            atomMenu.addAction("50%", lambda: self.setAtomSize(0.5))
+            atomMenu.addAction("75%", lambda: self.setAtomSize(0.75))
+            atomMenu.addAction("100%", lambda: self.setAtomSize(1.0))
+            atomMenu.addAction("150%", lambda: self.setAtomSize(1.5))
+            atomMenu.addAction("200%", lambda: self.setAtomSize(2.0))
+            # TODO: add custom atom size dialog
+            # atomMenu.addSeparator()
+            # atomMenu.addAction("Custom...", self.showAtomSizeDialog)
 
-        # Atom Size submenu
-        atomMenu = Loupe.addMenu("Atom Size")
-        atomMenu.addAction("50%", lambda: self.setAtomSize(0.5))
-        atomMenu.addAction("75%", lambda: self.setAtomSize(0.75))
-        atomMenu.addAction("100%", lambda: self.setAtomSize(1.0))
-        atomMenu.addAction("150%", lambda: self.setAtomSize(1.5))
-        atomMenu.addAction("200%", lambda: self.setAtomSize(2.0))
-        # TODO: add custom atom size dialog
-        # atomMenu.addSeparator()
-        # atomMenu.addAction("Custom...", self.showAtomSizeDialog) 
-
-        # Colors submenu
-        colorMenu = Loupe.addMenu("Colors")
-        colorMenu.addAction("Bond Color...", self.showBondColorPicker)
-        colorMenu.addAction("Background Color...", self.showBackgroundColorPicker)
+            # Colors submenu
+            colorMenu = Loupe.addMenu("Colors")
+            colorMenu.addAction("Bond Color...", self.showBondColorPicker)
+            colorMenu.addAction("Background Color...", self.showBackgroundColorPicker)
 
     def onSave(self):
         workdir = self.handler.workdir
@@ -357,21 +358,21 @@ class MenuHandler(EventClass):
         env.taskLoadZeroModel()
 
     def setBondWidth(self, width):
-        """Set bond width for the active Loupe."""
-        loupe = self.handler.getActiveLoupe()
+        """Set bond width for the current Loupe."""
+        loupe = self.window
         if not loupe:
             return
         loupe.settings.setParameter("bondWidth", width, refresh=True)
 
     def setAtomSize(self, scale):
-        """Set atom size scale for the active Loupe."""
-        loupe = self.handler.getActiveLoupe()
+        """Set atom size scale for the current Loupe."""
+        loupe = self.window
         if loupe and hasattr(loupe, 'settings'):
             loupe.settings.setParameter("atomSizeScale", scale, refresh=True)
 
     def showBondWidthDialog(self):
-        """Show custom bond width input dialog."""
-        loupe = self.handler.getActiveLoupe()
+        """Show custom bond width input dialog (current loupe)."""
+        loupe = self.window
         if not loupe:
             return
 
@@ -390,8 +391,8 @@ class MenuHandler(EventClass):
             self.setBondWidth(value)
 
     def showAtomSizeDialog(self):
-        """Show custom atom size input dialog."""
-        loupe = self.handler.getActiveLoupe()
+        """Show custom atom size input dialog. (current loupe)"""
+        loupe = self.window
         if not loupe:
             return
 
@@ -410,8 +411,8 @@ class MenuHandler(EventClass):
             self.setAtomSize(value)
 
     def showBondColorPicker(self):
-        """Show bond color picker dialog."""
-        loupe = self.handler.getActiveLoupe()
+        """Show bond color picker dialog. (current loupe)"""
+        loupe = self.window
         if not loupe:
             return
 
@@ -433,8 +434,8 @@ class MenuHandler(EventClass):
             loupe.settings.setParameter("bondColor", hex_color, refresh=True)
 
     def showBackgroundColorPicker(self):
-        """Show background color picker dialog."""
-        loupe = self.handler.getActiveLoupe()
+        """Show background color picker dialog. (current loupe)"""
+        loupe = self.window
         if not loupe:
             return
 

--- a/UI/menuHandler.py
+++ b/UI/menuHandler.py
@@ -64,7 +64,7 @@ class MenuHandler(EventClass):
             # File.addAction("Exit", self.onExit)
 
         # LOUPE
-        Loupe = mb.addMenu("&Loupe")
+        Loupe = mb.addMenu("&3D &View")
         Loupe.addAction("New", self.newLoupe, "Ctrl+n")
         Loupe.addSeparator()
         if self.mode == "loupe":

--- a/UI/menuHandler.py
+++ b/UI/menuHandler.py
@@ -123,7 +123,7 @@ class MenuHandler(EventClass):
                 return
 
             selected_energy_key, selected_force_key, prediction_keys = result
-        file_size = os.path.getsize(path) // 1_000_000_000
+        file_size = os.path.getsize(path) / 1_000_000_000
         slice_num = 0
         if file_size >= 5:
             slice_num = self.large_dataset_handle(file_size, logger)
@@ -133,9 +133,12 @@ class MenuHandler(EventClass):
             return
         elif slice_num == 0:
             env.taskLoadDataset(path, typ, selected_energy_key=selected_energy_key,
-                                selected_force_key=selected_force_key, prediction_keys=prediction_keys)
+                                selected_force_key=selected_force_key, prediction_keys=prediction_keys, slice_num=0)
         else:
             logger.info(f"loading dataset with slice: {slice_num}")
+            env.taskLoadDataset(path, typ, selected_energy_key=selected_energy_key,
+                                selected_force_key=selected_force_key, prediction_keys=prediction_keys,
+                                slice_num=slice_num)
 
     def large_dataset_handle(self, file_size, logger):
         from PySide6.QtWidgets import QDialog

--- a/UI/menuHandler.py
+++ b/UI/menuHandler.py
@@ -1,7 +1,41 @@
+import os
+import sys
 from events import EventClass
 from PySide6.QtWidgets import QFileDialog
 from UI.Templates import customFileDialog, BigDatasetWarningDialog
-import os
+from collections.abc import Mapping, Container
+from client.dataType import AtomsList
+
+
+def deep_getsizeof(obj, seen=None):
+    """
+    Function to calculate the size of an object on memory in bites.
+    :param obj: Desired object
+    :param seen: Flag to avoid double counting of objects.
+    :return: Size of the object in bytes.
+    """
+    if seen is None:
+        seen = set()
+
+    obj_id = id(obj)
+    if obj_id in seen:
+        return 0
+    seen.add(obj_id)
+
+    size = sys.getsizeof(obj)
+
+    if isinstance(obj, Mapping):
+        size += sum(deep_getsizeof(k, seen) + deep_getsizeof(v, seen) for k, v in obj.items())
+    elif isinstance(obj, (list, tuple, set, frozenset)):
+        size += sum(deep_getsizeof(i, seen) for i in obj)
+    elif hasattr(obj, "__dict__"):
+        size += deep_getsizeof(obj.__dict__, seen)
+    elif hasattr(obj, "__slots__"):
+        for slot in obj.__slots__:
+            if hasattr(obj, slot):
+                size += deep_getsizeof(getattr(obj, slot), seen)
+
+    return size
 
 
 class MenuHandler(EventClass):
@@ -124,26 +158,34 @@ class MenuHandler(EventClass):
 
             selected_energy_key, selected_force_key, prediction_keys = result
         file_size = os.path.getsize(path) / 1_000_000_000
-        slice_num = 0
-        if file_size >= 5:
-            slice_num = self.large_dataset_handle(file_size, logger)
+        slice_num = -1  # load entirely on RAM by default
+        if file_size >= 3:
+            slice_num = self.large_dataset_handle(path, logger)
 
-        if slice_num == -1:
+        if slice_num == -2:
             logger.info("load cancelled.")
             return
-        elif slice_num == 0:
-            env.taskLoadDataset(path, typ, selected_energy_key=selected_energy_key,
-                                selected_force_key=selected_force_key, prediction_keys=prediction_keys, slice_num=0)
-        else:
+        if slice_num > 0:
             logger.info(f"loading dataset with slice: {slice_num}")
-            env.taskLoadDataset(path, typ, selected_energy_key=selected_energy_key,
-                                selected_force_key=selected_force_key, prediction_keys=prediction_keys,
-                                slice_num=slice_num)
+        env.taskLoadDataset(path, typ, selected_energy_key=selected_energy_key, selected_force_key=selected_force_key,
+                            prediction_keys=prediction_keys, slice_num=slice_num)
 
-    def large_dataset_handle(self, file_size, logger):
+    def large_dataset_handle(self, path, logger):
         from PySide6.QtWidgets import QDialog
+        import ase.io
 
-        dialog = BigDatasetWarningDialog(file_size, self.handler.window)
+        logger.info("Large dataset detected, calculating the length.")
+        length = AtomsList.calc_dataset_length_static(path)
+        logger.info(f"Total dataset length: {length}")
+
+        logger.info("Total length calculated, approximating size of each atom in dataset.")
+        temp_dataset = ase.io.read(path, index=slice(0, 1000, None))
+        temp_size = deep_getsizeof(temp_dataset)  # the size of temp_dataset in bytes.
+        avg_per_atom_size = temp_size/1000
+        file_size = length*avg_per_atom_size
+        logger.info(f"Total size of the dataset on RAM would be approximately {file_size/1_000_000_000:.2f} GBs.")
+
+        dialog = BigDatasetWarningDialog(file_size, length, self.handler.window)
         result = dialog.exec()
         if result == QDialog.Accepted:
             slice_num = dialog.get_slice_number()
@@ -154,16 +196,19 @@ class MenuHandler(EventClass):
                         return slice_num
                     else:
                         logger.info("Invalid slice number entered, load abort.")
-                        return -1
+                        return -2
                 except (ValueError, TypeError):
                     logger.info("Invalid slice number entered, load abort.")
-                    return -1
+                    return -2
+            elif dialog.user_clicked_load_no_cache:
+                logger.info("User decided to load the whole dataset without caching.")
+                return -1
             else:
-                logger.info("User decided to load the whole dataset.")
+                logger.info("User decided to load the whole dataset with caching.")
                 return 0
         else:
             logger.info("User cancelled the load operation.")
-            return -1
+            return -2
 
 
 

--- a/client/dataType.py
+++ b/client/dataType.py
@@ -429,8 +429,11 @@ class AtomsList(UserList):
                 start += new_offset
             return result
         else:
-            if item >= self.N:
+            item = item if item >= 0 else item + self.N
+
+            if item >= self.N or item < 0:
                 raise IndexError(f"Index {item} out of range {self.N}")
+
             if not (self.start_index <= item < self.start_index + self.offset):
                 self.load_new_chunk(item)
 

--- a/client/dataType.py
+++ b/client/dataType.py
@@ -383,6 +383,41 @@ class AtomsList(UserList):
         del atoms, remaining_atoms
         return dataset_size
 
+    @staticmethod
+    def calc_dataset_length_static(path):
+        """
+        This method gets the path to a dataset and returns its length without reading the entire dataset.
+        For detailed explanation see the documentation for AtomsList.calc_dataset_length(self, path)...
+        :param path: Path to the dataset.
+        :return: length of the dataset.
+        """
+        size_gb = os.path.getsize(path) // 1_000_000_000
+        slice_size = 0
+        if size_gb < 1:
+            logger.info(f'Small dataset identified, no need for caching mechanism.')
+            slice_size = 5  # debug purposes
+        if 1 <= size_gb <= 5:  # change it so that the users choose the slice num
+            slice_size = 10  # read and then skip 10 atoms.
+            logger.info(f"Moderate size file (1 to 5 GB), setting the slice size to {slice_size}")
+        elif 5 < size_gb <= 10:
+            slice_size = 100  # skip 100
+            logger.info(f"Big file (5 to 10 GB), setting the slice size to {slice_size}")
+        elif size_gb > 10:
+            slice_size = 1000
+            logger.info(f"Gigantic file (10 to inf GB), setting the slice size to {slice_size}")
+
+        atoms = ase.io.read(path, index=slice(0, None, slice_size))
+        number_of_slice_chunks = len(atoms)
+
+        if number_of_slice_chunks == 0:
+            logger.error(f"Dataset ({path}) has no entries!!!")
+            return 0
+
+        remaining_atoms = ase.io.read(path, index=slice(slice_size * (number_of_slice_chunks - 1), None))
+        dataset_size = slice_size * (number_of_slice_chunks - 1) + len(remaining_atoms)
+        del atoms, remaining_atoms
+        return dataset_size
+
     def load_new_chunk(self, start):
         """
         Loads a new chunk from source dataset.

--- a/client/dataType.py
+++ b/client/dataType.py
@@ -328,7 +328,7 @@ class AtomsList(UserList):
         path (str): the path to the designated dataset.
         atoms_chunk (int): cache size (in terms of number of atoms).
     """
-    def __init__(self, path, atoms_chunk=100_000):
+    def __init__(self, path, atoms_chunk=300_000):
         super().__init__()
         self.offset = atoms_chunk
         self.start_index = 0

--- a/client/environment.py
+++ b/client/environment.py
@@ -992,6 +992,7 @@ class Environment(EventClass):
             if ("cluster" in cacheKey) and hasattr(dataset, 'isVariable') and dataset.isVariable:
                 logger.info("The cluster errors feature is not supported for variable datasets")
                 queue.discard(cacheKey)
+                self.eventPush('CLUSTER_FOR_VARIABLE')
                 continue
 
             if self.hasCacheKey(cacheKey):

--- a/client/environment.py
+++ b/client/environment.py
@@ -233,11 +233,16 @@ class Environment(EventClass):
             if slice_num is not None and slice_num > 0:
                 logger.info(f"Loading dataset with slice number of: {slice_num}")
                 atomsList = ase.io.read(path, index=slice(0, None, slice_num))
-            elif path.endswith(".traj"):
-                logger.info("Trajectory prediction dataset detected, loading with class ase.io.Trajectory")
-                atomsList = Trajectory(path)
+            elif slice_num is not None and slice_num == 0:
+                logger.info("Loading prediction dataset with caching.")
+                if path.endswith(".traj"):
+                    logger.info("Trajectory prediction dataset detected, loading with class ase.io.Trajectory")
+                    atomsList = Trajectory(path)
+                else:
+                    atomsList = AtomsList(path)
             else:
-                atomsList = AtomsList(path)
+                logger.info("Loading the dataset entirely on RAM.")
+                atomsList = ase.io.read(path, index=':')
 
             # atom_counts = [len(atoms) for atoms in atomsList] --> inefficient for large datasets because it
             # literally creates a copy of the entire dataset on RAM, just to check whether the dataset is variable or
@@ -328,11 +333,11 @@ class Environment(EventClass):
     def getMaxSize(self):
         return self.maxDatasetSize
 
-    def setNewDataset(self, dataset, slice_num=-1):
+    def setNewDataset(self, dataset, slice_num=-2):
         self.datasets[dataset.fingerprint] = dataset
         dataset.loaded = True
-        self.updateMaxSize(False, dataset)
-        if slice_num >= 0:  # to avoid adding slices for sub-datasets.
+        if slice_num != -2:  # to avoid adding slices for sub-datasets.
+            self.updateMaxSize(False, dataset)
             self.dataset_slice_numbers[dataset.fingerprint] = slice_num
         self.eventPush("DATASET_LOADED", dataset.fingerprint)
 
@@ -362,6 +367,9 @@ class Environment(EventClass):
         for cache_key in cache_keys_to_delete:
             del self.cache[cache_key]
             logger.info(f"Deleted cached data: {cache_key}")
+
+        if self.dataset_slice_numbers.get(key) is not None:  # We need to delete its slice number as well
+            del self.dataset_slice_numbers[key]
 
         dataset.onDelete()
         del self.datasets[key]

--- a/client/environment.py
+++ b/client/environment.py
@@ -9,7 +9,7 @@ from datasetLoaders.loader import (
 from modelLoaders.ghost import GhostModelLoader
 from modelLoaders.zeroModel import ZeroModelLoader
 from tasks import TaskManager
-from client.dataType import DataEntity
+from client.dataType import DataEntity, AtomsList
 from utils import md5FromArraysAndStrings
 from client.dataType import SubDataEntity
 import logging
@@ -41,6 +41,7 @@ class Environment(EventClass):
 
         # Note: might have multiple environments at some point
         self.datasets = {}
+        self.dataset_slice_numbers = {}
         self.models = {}
         self.cache = {}
         self.dataTypes = {}
@@ -228,13 +229,17 @@ class Environment(EventClass):
                 return True
 
             # Read once to detect type
-            if path.endswith(".traj"):
+            slice_num = self.dataset_slice_numbers.get(datasetKey)
+            if slice_num is not None and slice_num > 0:
+                logger.info(f"Loading dataset with slice number of: {slice_num}")
+                atomsList = ase.io.read(path, index=slice(0, None, slice_num))
+            elif path.endswith(".traj"):
                 logger.info("Trajectory prediction dataset detected, loading with class ase.io.Trajectory")
                 atomsList = Trajectory(path)
             else:
-                atomsList = ase.io.read(path, index=":")
+                atomsList = AtomsList(path)
 
-            # atom_counts = [len(atoms) for atoms in atomsList] --> super inefficient for large datasets because it
+            # atom_counts = [len(atoms) for atoms in atomsList] --> inefficient for large datasets because it
             # literally creates a copy of the entire dataset on RAM, just to check whether the dataset is variable or
             # fixed. Instead, the following probabilistic method:
             fixed_or_variable = check_homogeneity(atomsList)
@@ -323,11 +328,12 @@ class Environment(EventClass):
     def getMaxSize(self):
         return self.maxDatasetSize
 
-    def setNewDataset(self, dataset):
-        """Mark a dataset as available in the session and notify listeners."""
+    def setNewDataset(self, dataset, slice_num=-1):
         self.datasets[dataset.fingerprint] = dataset
         dataset.loaded = True
         self.updateMaxSize(False, dataset)
+        if slice_num >= 0:  # to avoid adding slices for sub-datasets.
+            self.dataset_slice_numbers[dataset.fingerprint] = slice_num
         self.eventPush("DATASET_LOADED", dataset.fingerprint)
 
     def getDataset(self, key):
@@ -380,7 +386,7 @@ class Environment(EventClass):
             return ds
 
     def taskLoadDataset(self, path, datasetType, selected_energy_key=None,
-                        selected_force_key=None, prediction_keys=None):
+                        selected_force_key=None, prediction_keys=None, slice_num=0):
         """Load dataset and optionally load predictions from same file.
         Args:
             path: Path to dataset file
@@ -388,6 +394,7 @@ class Environment(EventClass):
             selected_energy_key: Pre-selected energy key for reference (ASE only)
             selected_force_key: Pre-selected force key for reference (ASE only)
             prediction_keys: List of (energy_key, force_key, model_name) tuples
+            :param slice_num: slicing number for sampled load of datasets.
         """
         self.newTask(
             self.loadDataset,
@@ -396,6 +403,7 @@ class Environment(EventClass):
                 'selected_energy_key': selected_energy_key,
                 'selected_force_key': selected_force_key,
                 'prediction_keys': prediction_keys,
+                'slice_num': slice_num
             },
             visual=True,
             name="Loading dataset",
@@ -403,7 +411,7 @@ class Environment(EventClass):
         )
 
     def loadDataset(self, path, datasetType, taskID=None, selected_energy_key=None,
-                    selected_force_key=None, prediction_keys=None):
+                    selected_force_key=None, prediction_keys=None, slice_num=0):
         """Load dataset and create ghost models for prediction keys."""
         # logger.info(f"self.datasetTypes:\n{self.datasetTypes}\narg datasetType:\n{datasetType}")
         if not os.path.exists(path):
@@ -425,6 +433,7 @@ class Environment(EventClass):
                     selected_force_key=selected_force_key,
                     prediction_keys=prediction_keys,
                     show_dialog=False,  # Dialog already shown on main thread
+                    slice_num=slice_num
                 )
             except Exception as e:
                 logger.error(f"Failed to load dataset {path} in method 'loadDataset'")
@@ -450,7 +459,7 @@ class Environment(EventClass):
             return
 
         dataset.initialise()
-        self.setNewDataset(dataset)
+        self.setNewDataset(dataset, slice_num)
         logging.info(f"Dataset `{path}` successfully loaded")
 
         # Load predictions as ghost models if specified

--- a/modules/aseDataset.py
+++ b/modules/aseDataset.py
@@ -2,6 +2,7 @@ import os
 import logging
 import numpy as np
 from datasetLoaders.loader import DatasetLoader, VariableDatasetLoader
+from client.dataType import AtomsList
 import ase.io
 from ase.io.trajectory import Trajectory
 from collections.abc import Iterable
@@ -18,11 +19,12 @@ class aseDatasetLoader(DatasetLoader):
 
         # Read file only if atomsList not provided (avoid double-read)
         if atomsList is None:
+            logger.warning("atomsList was none, hence loading the entire dataset.")
             if path.endswith(".traj"):
                 logger.info("Trajectory dataset detected, loading with class ase.io.Trajectory")
                 self.atomsList = Trajectory(path)
             else:
-                self.atomsList = ase.io.read(path, index=":")
+                self.atomsList = AtomsList(path)
         else:
             self.atomsList = atomsList
 
@@ -222,11 +224,12 @@ class VariableASEDatasetLoader(VariableDatasetLoader):
 
         # Read file only if atomsList not provided (avoid double-read)
         if atomsList is None:
+            logger.warning("atomsList was none, hence loading the entire dataset.")
             if path.endswith(".traj"):
                 logger.info("Trajectory dataset detected, loading with class ase.io.Trajectory")
                 self.atomsList = Trajectory(path)
             else:
-                self.atomsList = ase.io.read(path, index=":")
+                self.atomsList = AtomsList(path)
         else:
             self.atomsList = atomsList
 
@@ -420,7 +423,7 @@ def loadData(env):
             return True
 
         def __call__(self, path: str, selected_energy_key=None, selected_force_key=None,
-                     prediction_keys=None, show_dialog=True):
+                     prediction_keys=None, show_dialog=True, slice_num=0):
             """Load ASE dataset with optional key selection.
 
             Args:
@@ -434,13 +437,16 @@ def loadData(env):
                 tuple: (dataset_loader, prediction_keys) or (None, None) if cancelled
             """
             # Read file ONCE
-            if path.endswith(".traj"):
-                logger.info("Trajectory dataset detected, loading with class ase.io.Trajectory")
-                atomsList = Trajectory(path)
+            if slice_num == 0:
+                if path.endswith(".traj"):
+                    logger.info("Trajectory dataset detected, loading with class ase.io.Trajectory")
+                    atomsList = Trajectory(path)
+                else:
+                    atomsList = AtomsList(path)
             else:
-                atomsList = ase.io.read(path, index=":")
+                atomsList = ase.io.read(path, index=slice(0, None, slice_num))
 
-            # atom_counts = [len(atoms) for atoms in atomsList] --> super inefficient for large datasets because it
+            # atom_counts = [len(atoms) for atoms in atomsList] --> inefficient for large datasets because it
             # literally creates a copy of the entire dataset on RAM, just to check whether the dataset is variable or
             # fixed. Instead, the following probabilistic method:
             fixed_or_variable = self.check_homogeneity(atomsList)
@@ -469,7 +475,7 @@ def loadData(env):
                     prediction_keys = selection['predictions']
 
             # Create loader with selected keys passed to constructor
-            if fixed_or_variable == 1:
+            if fixed_or_variable:
                 # Uniform dataset
                 logger.info(f"Loading uniform ASE dataset: {len(atomsList)} molecules, {len(atomsList[0])} atoms each")
                 loader = aseDatasetLoader(

--- a/modules/aseDataset.py
+++ b/modules/aseDataset.py
@@ -20,11 +20,7 @@ class aseDatasetLoader(DatasetLoader):
         # Read file only if atomsList not provided (avoid double-read)
         if atomsList is None:
             logger.warning("atomsList was none, hence loading the entire dataset.")
-            if path.endswith(".traj"):
-                logger.info("Trajectory dataset detected, loading with class ase.io.Trajectory")
-                self.atomsList = Trajectory(path)
-            else:
-                self.atomsList = AtomsList(path)
+            self.atomsList = ase.io.read(path, index=':')
         else:
             self.atomsList = atomsList
 
@@ -225,11 +221,7 @@ class VariableASEDatasetLoader(VariableDatasetLoader):
         # Read file only if atomsList not provided (avoid double-read)
         if atomsList is None:
             logger.warning("atomsList was none, hence loading the entire dataset.")
-            if path.endswith(".traj"):
-                logger.info("Trajectory dataset detected, loading with class ase.io.Trajectory")
-                self.atomsList = Trajectory(path)
-            else:
-                self.atomsList = AtomsList(path)
+            self.atomsList = ase.io.read(path, index=':')
         else:
             self.atomsList = atomsList
 
@@ -443,6 +435,8 @@ def loadData(env):
                     atomsList = Trajectory(path)
                 else:
                     atomsList = AtomsList(path)
+            elif slice_num == -1:
+                atomsList = ase.io.read(path, index=':')
             else:
                 atomsList = ase.io.read(path, index=slice(0, None, slice_num))
 

--- a/modules/basicErrors.py
+++ b/modules/basicErrors.py
@@ -709,3 +709,209 @@ def loadUI(UIHandler, env):
 
     # argument are (row, col, rowSpan, colSpan)
     ct.addWidget(scrollContainer, 2, 0, 1, 2)
+
+    # Moving scatter errors to basic Errors
+
+    class EnergyScatterPlot(BasicPlotWidget):
+        def __init__(self, handler, **kwargs):
+            super().__init__(
+                handler,
+                title="Energy Scatter",
+                name="Energy Scatter",
+                **kwargs,
+            )
+            self.setDataDependencies("energy")
+            self.setXLabel("True Energy", getConfig("energyUnit"))
+            self.setYLabel("Predicted Energy", getConfig("energyUnit"))
+
+            # this list will save which indices are currently selected for each plot
+            # since there's a maximum number of indices on a scatter plot
+            # see "scatterPlotNPoints" in the config file
+            self.indices = {}
+            self.eventSubscribe(
+                "ENERGY_SHIFT_CHANGED", self.onEnergyShiftChanged
+            )
+
+        def onEnergyShiftChanged(self):
+            shifted = self.handler.energyShiftEnabled
+            self.titleLabel.setText(
+                "Energy Scatter (shifted)"
+                if shifted
+                else "Energy Scatter"
+            )
+            self.visualRefresh(force=True)
+
+        def addPlots(self):
+            self.indices.clear()
+            shifted = self.handler.energyShiftEnabled
+            for data in self.getWatchedData():
+
+                predE = data["dataEntry"].get("energy")
+                trueE = data["dataset"].getEnergies()
+
+                if shifted:
+                    shift = np.mean(predE - trueE)
+                    predE = predE - shift
+
+                # this is a unique key for the model/dataset combination
+                # perfect for saving the indices below uniquely
+                key = self.getKey(data["dataset"], data["model"])
+
+                n = getConfig("scatterPlotNPoints")
+                if len(predE) > n:
+                    idx = np.round(np.linspace(0, len(predE) - 1, n)).astype(
+                        int
+                    )
+                    predE = predE[idx]
+                    trueE = trueE[idx]
+                    self.indices[key] = idx
+                else:
+                    self.indices[key] = None
+
+                self.plot(
+                    trueE, predE, autoColor=data, scatter=True, autoLabel=data
+                )
+
+        def getKey(self, dataset, model):
+            # Creates a unique key based on the dataset/model combination
+            # perfect for saving the indices for each plot item, needed when
+            # subbing (see getDatasetSubIndices)
+            return f"{dataset.fingerprint}__{model.fingerprint}"
+
+        def getDatasetSubIndices(self, dataset, model):
+            (xRange, yRange) = self.getRanges()
+            key = self.getKey(dataset, model)
+            idxs = self.indices[key]
+
+            x0, x1 = xRange
+            y0, y1 = yRange
+
+            de = self.env.getData("energy", dataset=dataset, model=model)
+            predE = de.get("energy")
+            trueE = dataset.getEnergies()
+
+            xTruth = (predE > x0) & (predE < x1)
+            yTruth = (trueE > y0) & (trueE < y1)
+            args = np.argwhere(xTruth & yTruth).flatten()
+
+            if idxs is None:
+                return args
+            else:
+                return idxs[args]
+
+    plt = EnergyScatterPlot(UIHandler, parent=ct)
+    ct.addWidget(plt, 3, 0)
+    ct.addDataSelectionCallback(plt.setModelDatasetDependencies)
+
+    class ForcesScatterPlot(BasicPlotWidget):
+        def __init__(self, handler, **kwargs):
+            super().__init__(
+                handler,
+                title="Forces Scatter",
+                name="Forces Scatter",
+                **kwargs,
+            )
+            self.setDataDependencies("forces")
+            self.setXLabel("True Forces", getConfig("forcesUnit"))
+            self.setYLabel("Predicted Forces", getConfig("forcesUnit"))
+
+            self.indices = {}
+
+        def getKey(self, dataset, model):
+            # Creates a unique key based on the dataset/model combination
+            # perfect for saving the indices for each plot item, needed when
+            # subbing (see getDatasetSubIndices)
+            return f"{dataset.fingerprint}__{model.fingerprint}"
+
+        def addPlots(self):
+
+            for data in self.getWatchedData():
+                dataset = data["dataset"]
+                pred_forces = data["dataEntry"].get("forces")
+                true_forces = dataset.getForces()
+
+                # Handle variable vs uniform datasets
+                if isinstance(pred_forces, list):
+                    # Variable dataset: concatenate and flatten
+                    predE = np.concatenate([f.flatten() for f in pred_forces])
+                    trueE = np.concatenate([f.flatten() for f in true_forces])
+                else:
+                    # Uniform dataset: flatten directly
+                    predE = pred_forces.flatten()
+                    trueE = true_forces.flatten()
+
+                key = self.getKey(dataset, data["model"])
+
+                n = getConfig("scatterPlotNPoints")
+                if len(predE) > n:
+                    idx = np.round(np.linspace(0, len(predE) - 1, n)).astype(
+                        int
+                    )
+                    predE = predE[idx]
+                    trueE = trueE[idx]
+                    self.indices[key] = idx
+                else:
+                    self.indices[key] = None
+
+                self.plot(
+                    trueE, predE, autoColor=data, scatter=True, autoLabel=data
+                )
+
+        def getDatasetSubIndices(self, dataset, model):
+            (xRange, yRange) = self.getRanges()
+            key = self.getKey(dataset, model)
+            idxs = self.indices[key]
+
+            x0, x1 = xRange
+            y0, y1 = yRange
+
+            de = self.env.getData("forces", dataset=dataset, model=model)
+            pred_forces = de.get("forces")
+            true_forces = dataset.getForces()
+
+            # Handle variable vs uniform datasets
+            if isinstance(pred_forces, list):
+                # Variable dataset: concatenate and flatten
+                predF = np.concatenate([f.flatten() for f in pred_forces])
+                trueF = np.concatenate([f.flatten() for f in true_forces])
+            else:
+                # Uniform dataset: flatten directly
+                predF = pred_forces.flatten()
+                trueF = true_forces.flatten()
+
+            xTruth = (predF > x0) & (predF < x1)
+            yTruth = (trueF > y0) & (trueF < y1)
+            args = np.argwhere(xTruth & yTruth).flatten()
+
+            if idxs is None:
+                idxs = args
+            else:
+                idxs = idxs[args]
+
+            # this is indices of the flattened forces by component
+            # but we need the index of the geometry
+            if hasattr(dataset, 'isVariable') and dataset.isVariable:
+                # Variable dataset: use molecule_offsets to map flat indices to molecules
+                # Each flat index corresponds to a force component (atom * 3)
+                # We need to find which molecule each flat index belongs to
+                atom_offsets = dataset.molecule_offsets  # [0, n1, n1+n2, ...]
+                force_offsets = atom_offsets * 3  # Convert to force component offsets
+
+                # For each flat index, find which molecule it belongs to
+                mol_indices = []
+                for idx in idxs:
+                    # Find which molecule this flat index belongs to
+                    mol_idx = np.searchsorted(force_offsets[1:], idx, side='right')
+                    mol_indices.append(mol_idx)
+
+                idxs = np.unique(mol_indices).astype(int)
+            else:
+                # Uniform dataset: all molecules have same number of atoms
+                nEntriesPerConf = dataset.getNAtoms() * 3
+                idxs = np.unique(np.floor(idxs / nEntriesPerConf)).astype(int)
+
+            return idxs
+
+    plt = ForcesScatterPlot(UIHandler, parent=ct)
+    ct.addWidget(plt, 3, 1)
+    ct.addDataSelectionCallback(plt.setModelDatasetDependencies)

--- a/modules/clusterError.py
+++ b/modules/clusterError.py
@@ -33,7 +33,7 @@ def agglomerative(desc, n, nInitPoints, env, taskID):
     lDescRest = len(descRest)
 
     cinitLabels = AgglomerativeClustering(
-        affinity="euclidean", n_clusters=n, linkage="complete"
+        metric="euclidean", n_clusters=n, linkage="complete"
     ).fit_predict(descInit)
 
     # gather cluster data from labels and return to original indices

--- a/modules/errorScatter.py
+++ b/modules/errorScatter.py
@@ -1,4 +1,4 @@
-import numpy as np
+"""import numpy as np
 from config.userConfig import getConfig
 import logging
 
@@ -216,3 +216,4 @@ def loadUI(UIHandler, env):
     plt = ForcesScatterPlot(UIHandler, parent=ct)
     ct.addWidget(plt, 0, 1)
     ct.addDataSelectionCallback(plt.setModelDatasetDependencies)
+"""


### PR DESCRIPTION
In this version I did the following:

- Improved AtomsList datastructure for more efficient processing of big datasets on RAM.
- Added options for big datasets to either fully load the dataset, or load it with caching (AtomsList) or sampling from the dataset.
- User is able to choose between the mentioned options while loading large datasets. Also, when deciding to sample from the dataset, depending on the slicing number the user chooses, an approximation of "how many bytes would this dataset use on RAM" will be shown to the user.
- Loupes are now changed "3D View"s.
- Each "3D View" window has its own handler, so different "3D View"s can have different configurations (datasets, atoms' size, bonds' size, etc.).
- Scatter Errors are moved to Basic Errors tab.
- When the user wants to use clustering features for variable datasets, not only the program will catch the exception, but also it will show a notification window for the user stating this feature is not available for variable datasets.